### PR TITLE
D10 compatible

### DIFF
--- a/menu_section.info.yml
+++ b/menu_section.info.yml
@@ -2,6 +2,6 @@ name: Menu Section
 type: module
 description: 'Creates site sections with the menu.'
 package: menu
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - current_menu

--- a/src/MenuSectionFormNodeFormAlter.php
+++ b/src/MenuSectionFormNodeFormAlter.php
@@ -23,6 +23,7 @@ class MenuSectionFormNodeFormAlter {
       if ($available = $nodeType->getThirdPartySetting('menu_ui', 'available_menus', ['main'])) {
         $query->condition('menu_name', array_values($available), 'NOT IN');
       }
+      $query->accessCheck(FALSE);
       $linkIds = $query->execute();
       if ($linkIds) {
         $menu = MenuLinkContent::load(reset($linkIds))->getMenuName();

--- a/src/MenuSectionFormNodeFormAlter.php
+++ b/src/MenuSectionFormNodeFormAlter.php
@@ -23,7 +23,7 @@ class MenuSectionFormNodeFormAlter {
       if ($available = $nodeType->getThirdPartySetting('menu_ui', 'available_menus', ['main'])) {
         $query->condition('menu_name', array_values($available), 'NOT IN');
       }
-      $query->accessCheck(FALSE);
+      $query->accessCheck(TRUE);
       $linkIds = $query->execute();
       if ($linkIds) {
         $menu = MenuLinkContent::load(reset($linkIds))->getMenuName();


### PR DESCRIPTION
Fixed two problems:

- `access_check.node.add` was removed. Followed the suggestion https://www.drupal.org/node/2836069
- web/modules/contrib/menu_section/src/MenuSectionFormNodeFormAlter.php	26	Relying on entity queries to check access by default is deprecated in drupal:9.2.0 and an error will be thrown from drupal:10.0.0. Call \Drupal\Core\Entity\Query\QueryInterface::accessCheck() with TRUE or FALSE to specify whether access should be checked.